### PR TITLE
Allow for afs-based shared settings

### DIFF
--- a/disco/settings.py
+++ b/disco/settings.py
@@ -9,7 +9,7 @@ import semantic_version
 from django.utils.translation import gettext_lazy as _
 
 try:
-    from arches.settings import *
+    from arches_for_science.settings import *
 except ImportError:
     pass
 
@@ -178,18 +178,6 @@ TEMPLATES = build_templates_config(
                     "arches_for_science.utils.context_processors.project_settings"
                 ]
 )
-
-FORMATS = [
-    {"name": "Bruker M6 (point)", "id": "bm6", "renderer": "31be40ae-dbe6-4f41-9c13-1964d7d17042"},
-    {"name": "Bruker 5g", "id": "b5g", "renderer": "31be40ae-dbe6-4f41-9c13-1964d7d17042"},
-    {"name": "Bruker Tracer IV-V", "id": "bt45", "renderer": "31be40ae-dbe6-4f41-9c13-1964d7d17042"},
-    {"name": "Bruker Tracer III", "id": "bt3", "renderer": "31be40ae-dbe6-4f41-9c13-1964d7d17042"},
-    {"name": "Bruker 5i", "id": "b5i", "renderer": "31be40ae-dbe6-4f41-9c13-1964d7d17042"},
-    {"name": "Bruker Artax", "id": "bart", "renderer": "31be40ae-dbe6-4f41-9c13-1964d7d17042"},
-    {"name": "Renishaw InVia - 785", "id": "r785", "renderer": "94fa1720-6773-4f99-b49b-4ea0926b3933"},
-    {"name": "Ranishsaw inVia - 633/514", "id": "r633", "renderer": "94fa1720-6773-4f99-b49b-4ea0926b3933"},
-    {"name": "ASD FieldSpec IV hi res", "id": "asd", "renderer": "88dccb59-14e3-4445-8f1b-07f0470b38bb"},
-]
 
 ALLOWED_HOSTS = []
 

--- a/disco/settings.py
+++ b/disco/settings.py
@@ -8,10 +8,7 @@ import inspect
 import semantic_version
 from django.utils.translation import gettext_lazy as _
 
-try:
-    from arches_for_science.settings import *
-except ImportError:
-    pass
+from arches_for_science.settings import *
 
 APP_NAME = 'disco'
 APP_VERSION = semantic_version.Version(major=0, minor=0, patch=0)


### PR DESCRIPTION
Arches for science has a bunch of settings (renderers, formats, etc) that may not vary by project.  This PR imports the common afs settings file, which imports the common arches settings file, still allowing for override at the project level.  