### PR TITLE
Add staticfiles key to STORAGES

### DIFF
--- a/disco/settings.py
+++ b/disco/settings.py
@@ -368,6 +368,9 @@ STORAGES = {
     "default": {
         "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
     },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
 }
 AWS_STORAGE_BUCKET_NAME = "disco-dev-test-bucket"
 DOCKER=False


### PR DESCRIPTION
Apparently, configuring STORAGES at all (e.g. for default) means you need to also specify the staticfiles key if you were relying on the old implicit default for `STATICFILES_STORAGE`.

To test, visit the Django admin.

Before:
```
InvalidStorageError at /admin/
Could not find config for 'staticfiles' in settings.STORAGES.
```