### PR TITLE
Updates disco install requirements

### DIFF
--- a/disco/install/requirements.txt
+++ b/disco/install/requirements.txt
@@ -1,1 +1,2 @@
-arches==7.5.0
+arches~=7.5.0a0
+arches-for-science~=1.1.0a0


### PR DESCRIPTION
Allow upgrade to any 7.5.x version of arches, and any 1.1.x version of afs.