### PR TITLE
Adds XY renderer

### DIFF
--- a/disco/settings.py
+++ b/disco/settings.py
@@ -444,17 +444,6 @@ RENDERERS += [
         "type": "text/plain",   
         "exclude": "",
     },
-    {
-        "name": "xy-reader",
-        "title": "XY Data File Reader",
-        "description": "Use for all instrument outputs with x-y data",
-        "id": "e93b7b27-40d8-4141-996e-e59ff08742f3",
-        "iconclass": "fa fa-bolt",
-        "component": "views/components/cards/file-renderers/xy-reader",
-        "ext": "txt",
-        "type": "text/plain",   
-        "exclude": "",
-    },
 ]
 
 X_FRAME_OPTIONS = "SAMEORIGIN"

--- a/disco/settings.py
+++ b/disco/settings.py
@@ -433,15 +433,28 @@ RENDERERS += [
         "type": "",
         "exclude": "",
     },
-    # {
-    #     "name": "colladareader",
-    #     "id": "3732bdf0-74b1-412f-955a-9ca038e7db31",
-    #     "iconclass": "fa fa-spoon",
-    #     "component": "views/components/cards/file-renderers/colladareader",
-    #     "ext": "dae",
-    #     "type": "",
-    #    "exclude": [],
-    # },
+    {
+        "name": "xy-reader",
+        "title": "XY Data File Reader",
+        "description": "Use for all instrument outputs with x-y data",
+        "id": "e93b7b27-40d8-4141-996e-e59ff08742f3",
+        "iconclass": "fa fa-bolt",
+        "component": "views/components/cards/file-renderers/xy-reader",
+        "ext": "txt",
+        "type": "text/plain",   
+        "exclude": "",
+    },
+    {
+        "name": "xy-reader",
+        "title": "XY Data File Reader",
+        "description": "Use for all instrument outputs with x-y data",
+        "id": "e93b7b27-40d8-4141-996e-e59ff08742f3",
+        "iconclass": "fa fa-bolt",
+        "component": "views/components/cards/file-renderers/xy-reader",
+        "ext": "txt",
+        "type": "text/plain",   
+        "exclude": "",
+    },
 ]
 
 X_FRAME_OPTIONS = "SAMEORIGIN"


### PR DESCRIPTION
We'd probably be better served by saving these renderers in the DB instead of in config.  That'll be a core change.

This depends on https://github.com/archesproject/arches-for-science/pull/1287