### PR TITLE
update webpack config #23

### DIFF
--- a/disco/webpack/webpack.config.dev.js
+++ b/disco/webpack/webpack.config.dev.js
@@ -20,16 +20,7 @@ module.exports = () => {
                 devServer: {
                     historyApiFallback: true,
                     client: {
-                        overlay: {
-                            errors: true,
-                            warnings: false,
-                            runtimeErrors: (error) => {
-                                if (error.message === "ResizeObserver loop limit exceeded") {
-                                  return false;
-                                }
-                                return true;
-                            },
-                        },
+                        overlay: false,
                     },
                     hot: true,
                     host: '0.0.0.0',


### PR DESCRIPTION
I have been testing this by iterating through the XY Data workflow, and noticing that the `select2` errors now only appear in the dev console.