### PR TITLE
Add temporary overrides to support new example report template

### DIFF
--- a/disco/media/js/views/components/workflows/project-report-workflow/download-project-files.js
+++ b/disco/media/js/views/components/workflows/project-report-workflow/download-project-files.js
@@ -1,0 +1,168 @@
+define([
+    'knockout',
+    'arches',
+    'templates/views/components/workflows/project-report-workflow/download-project-files.htm',
+], function(ko, arches, downloadFilesTemplate) {
+    function viewModel(params) {
+        var self = this;
+
+        this.projectValue = params.projectId;
+        const physicalThings = params.physicalThings;
+
+        const observationGraphId = '615b11ee-c457-11e9-910c-a4d18cec433a';
+        const digitalResourcegGraphId = '707cbd78-ca7a-11e9-990b-a4d18cec433a';
+        const collectionGraphId = '1b210ef3-b25c-11e9-a037-a4d18cec433a';
+        const physicalThingGraphId = '9519cb4f-b25b-11e9-8c7b-a4d18cec433a';
+        const fileNodeId = '7c486328-d380-11e9-b88e-a4d18cec433a';
+        const objectObservedNodeId = "cd412ac5-c457-11e9-9644-a4d18cec433a";
+        const removalFromObjectNodegroupId = "b11f217a-d2bc-11e9-8dfa-a4d18cec433a";
+        const removedFromNodeId = "38814345-d2bd-11e9-b9d6-a4d18cec433a";
+        const fileStatementContentNodeId = 'ca227726-78ed-11ea-a33b-acde48001122';
+        this.relatedObservations = ko.observableArray();
+        this.startIds = ko.observableArray();
+        this.message = ko.observable();
+
+        this.selectedFiles = ko.observableArray();
+
+        if (ko.unwrap(params.value)) {
+            const files =  params.value().files;
+            files?.forEach((file) => {
+                self.startIds.push(file.fileid);                    
+                self.selectedFiles.push(file);
+            });
+        };
+
+        this.selectedFiles.subscribe((val) => {
+            params.value({ files: val });
+        });
+        
+        params.value({ files: [] });
+
+        this.numberOfSelectedFiles = ko.computed(() => {
+            const count = self.relatedObservations().reduce((acc, observation) => {
+                return acc + observation.relatedFiles().filter(file => file.selected()).length;
+            }, 0);
+            return count;
+        });
+
+        this.numberOfFiles = ko.computed(() => {
+            const count = self.relatedObservations().reduce((acc, observation) => {
+                return acc + observation.relatedFiles().length;
+            }, 0);
+            return count;
+        });
+
+        this.fileTableConfig = {
+            columns: Array(4).fill(null)
+        };
+
+        this.expandAll = function(bool) {
+            self.relatedObservations().forEach((observation) => {
+                observation.expanded(bool);
+            });
+        };
+
+        this.toggleSelection = function(observation) {
+            const noFilesSelected = observation.relatedFiles().
+                filter(file => file.selected()).length === 0;
+            const selectedValue = noFilesSelected;
+
+            observation.relatedFiles().forEach(file => file.selected(selectedValue));
+            if(selectedValue) {
+                observation.expanded(true);
+            }
+        };
+
+        const addSelectedFiles = () => {
+            self.selectedFiles.removeAll();
+            self.relatedObservations().forEach((observation) => {
+                observation.relatedFiles().forEach((file) => {
+                    if (file.selected()) {
+                        self.selectedFiles.push({
+                            'name': file.name,
+                            'fileid': file.file_id,
+                            'project': self.projectName,
+                            'interpretation': file.interpretation,
+                            'observation': observation.displayname,
+                            'parameters': observation.description
+                        });
+                    }
+                });
+            });
+        };
+
+        params.form.reset = () => {
+            self.selectedFiles.removeAll();
+            self.relatedObservations().forEach((observation) => {
+                observation.relatedFiles().forEach((file) => {
+                    if (self.startIds().includes(file.file_id)) {
+                        file.selected(true);
+                    } else {
+                        file.selected(false);
+                    }
+                });
+            });
+            addSelectedFiles();
+        };
+
+        this.getFilesFromObservation = async() => {
+            const projectResponse = await window.fetch(arches.urls.related_resources + self.projectValue  + "?paginate=false");
+            const projectJson = await projectResponse.json();
+
+            const collectionForProject = projectJson.related_resources.find((res) => res.graph_id === collectionGraphId).resourceinstanceid;
+            const collectionResponse = await window.fetch(arches.urls.related_resources + collectionForProject  + "?paginate=false");
+            const collectionJson = await collectionResponse.json();
+
+            const projectPhysicalThings = collectionJson.related_resources.filter((res) => res.graph_id === physicalThingGraphId)
+                .filter((res) => {
+                    const removedFromTile = res.tiles.find((tile) => tile.nodegroup_id === removalFromObjectNodegroupId);
+                    const removedFrom = removedFromTile?.data[removedFromNodeId].map((rr) => rr.resourceId);
+                    return removedFrom?.some((res) => physicalThings.includes(res)) || physicalThings.includes(res.resourceinstanceid);
+                }).map((res) => res.resourceinstanceid);
+
+            self.projectName = projectJson.resource_instance.displayname;
+            const projectObservations = projectJson.related_resources.filter((res) => res.graph_id == observationGraphId)
+                .filter((res) => {
+                    const objectTile = res.tiles.find((tile) => tile.nodegroup_id === objectObservedNodeId);
+                    const object = objectTile?.data[objectObservedNodeId][0]['resourceId'];
+                    return projectPhysicalThings.includes(object);
+                });
+
+            const selectedFileIds = self.selectedFiles().map((file) => file.fileid);
+            for (const projectObservation of projectObservations) {
+                const relatedFiles = ko.observableArray();
+                const response = await window.fetch(arches.urls.related_resources + projectObservation.resourceinstanceid  + "?paginate=false");
+                
+                if(response.ok) {
+                    const json = await response.json();
+                    const observation = json.resource_instance;
+                    observation.expanded = ko.observable();
+                    observation.description = observation.descriptors[arches.activeLanguage].description;
+                    const digitalResources = json.related_resources.filter((res) => res.graph_id == digitalResourcegGraphId);
+                    digitalResources.forEach((res) => 
+                        res.tiles.forEach((tile) => {
+                            if (tile.nodegroup_id == fileNodeId) {
+                                const selected = ko.observable();
+                                if (selectedFileIds.includes(tile.data[fileNodeId][0].file_id)) { selected(true); }
+                                selected.subscribe(() => addSelectedFiles());
+                                const interpretation = res.tiles.find((tile2) => tile2.parenttile_id == tile.tileid)?.data[fileStatementContentNodeId][arches.activeLanguage].value;
+                                const file = { ...tile.data[fileNodeId][0], interpretation, selected };
+                                relatedFiles.push(file);
+                            }
+                        })
+                    );
+                    self.relatedObservations.push({ ...observation, relatedFiles});
+                }
+            }
+            self.relatedObservations.sort((a,b) => b.relatedFiles().length - a.relatedFiles().length);
+        };
+
+        this.getFilesFromObservation();
+    }
+
+    ko.components.register('download-project-files', {
+        viewModel: viewModel,
+        template: downloadFilesTemplate
+    });
+    return viewModel;
+});

--- a/disco/media/js/views/components/workflows/project-report-workflow/download-report.js
+++ b/disco/media/js/views/components/workflows/project-report-workflow/download-report.js
@@ -1,0 +1,169 @@
+define([
+    'underscore',
+    'arches',
+    'knockout',
+    'js-cookie',
+    'utils/report',
+    'viewmodels/alert-json',
+    'templates/views/components/workflows/project-report-workflow/download-report.htm'
+], function(_, arches, ko, cookies, reportUtils, JsonErrorAlertViewModel, downloadReportTemplate) {
+    function viewModel(params) {
+        const observationGraphId = "615b11ee-c457-11e9-910c-a4d18cec433a";
+        const collectionGraphId = "1b210ef3-b25c-11e9-a037-a4d18cec433a";
+        const physicalThingGraphId = "9519cb4f-b25b-11e9-8c7b-a4d18cec433a";
+
+        const ramanConceptValueId = "6418248a-bcf5-408b-9bed-2dbfc996f922";
+        const xrfConceptValueId = "c8d6ea37-ebd1-45df-ae96-bfd8201c3f99";
+
+        const self = this;
+        const projectId = params.projectId;
+        const physicalThingFromPreviousStep = params.physicalThingIds;
+        const projectFiles = params.projectFiles;
+        this.message = ko.observable();
+        this.loading = ko.observable(false);
+        this.templates = ko.observableArray(params.templates);
+        const screenshots = params.annotationStepData ? params.annotationStepData.screenshots : [];
+        const lbgApiEndpoint = `${arches.urls.api_bulk_disambiguated_resource_instance}?v=beta&resource_ids=`;
+        const projectDetailsUrl = lbgApiEndpoint + projectId;
+        
+        const regex = /filename\*?=['"]?(?:UTF-\d['"]*)?([^;\r\n"']*)['"]?;?/i;
+
+        this.downloadInfo = ko.observableArray();
+        this.errorInfo = ko.observableArray();
+        this.projectName = ko.observable();
+
+        const getRelatedResources = async function(resourceid) {
+            const response = await window.fetch(arches.urls.related_resources + resourceid + "?paginate=false");
+
+            if (response.ok) {
+                return await response.json();
+            } else { 
+                throw('error retrieving related resources', response); // throw - this should never happen, therefore not i18n'd.
+            }
+
+        };
+
+        const getProjectName = async() => {
+            const response = await fetch(`${arches.urls.api_resources(projectId)}?format=json`);
+            const data = await response.json();
+            self.projectName(data.displayname);
+        };
+        getProjectName();
+
+        this.generateReport = async() => {
+            self.loading(true);
+            self.message(arches.translations.generatingReportMessage)
+            const relatedObjects = await getRelatedResources(projectId);
+            const collections = relatedObjects.related_resources.filter(rr => rr.graph_id == collectionGraphId);
+            const allPhysicalThingsResponse = collections.map(async(collection) => {
+                const collectionRelatedResources = await getRelatedResources(collection.resourceinstanceid);
+                return collectionRelatedResources?.related_resources.filter(rr => rr.graph_id == physicalThingGraphId);
+            });
+
+            self.physicalThings = [].concat(...(await Promise.all(allPhysicalThingsResponse))).filter(res => {
+                return physicalThingFromPreviousStep.includes(res.resourceinstanceid);
+            });
+
+            const physicalThingDetailsUrl = self.physicalThings.reduce(
+                (acc, current) => acc + current.resourceinstanceid + ",", 
+                lbgApiEndpoint
+            ).replace(/,$/, '');
+
+            const observations = relatedObjects.related_resources.filter(resource => resource.graph_id == observationGraphId);
+            
+            const observationIds = observations.reduce((accumulator, currentValue)=> {
+                accumulator.push(currentValue.resourceinstanceid);
+                return accumulator;
+            }, []).join(",");
+            
+            const observationDetails = observationIds ? await (await window.fetch(`${lbgApiEndpoint}${observationIds}`)).json() : {};
+            const physicalThingsDetails = await (await window.fetch(physicalThingDetailsUrl)).json();
+            const projectDetails = await (await window.fetch(projectDetailsUrl)).json();
+            
+            const today = new Date();
+            const options = { year: 'numeric', month: 'long', day: 'numeric' };
+            // TODO(i18n) -- can we get the locale from django?
+            const reportDate = today.toLocaleDateString('en-US', options);
+            const physicalThingsDetailsArray = [...Object.values(physicalThingsDetails)];
+            const objectOfStudyDetailsArray = physicalThingsDetailsArray.filter(thing => physicalThingFromPreviousStep.includes(thing.resourceinstanceid));
+            const analysisAreas = physicalThingsDetailsArray.filter(physicalThing => physicalThing.resource?.type?.["@display_value"] == 'analysis areas');
+            const annotationScreenshots = screenshots?.map((screenshot) => {
+                const url = `${window.location.origin}/temp_file/${screenshot.fileId}`;
+                return {...screenshot, url};
+            });
+            const files = projectFiles;
+
+            const templates = self.templates().map((template) => ({
+                templateId: template.id,
+                filename: reportUtils.slugify(`${self.projectName()}_${template.name}_${reportDate}`)
+            }));
+
+            data = {
+                projectId,
+                templates,
+                annotationScreenshots,
+                reportDate,
+                analysisAreas,
+                ramanObservationDetails: [
+                    ...Object.values(observationDetails).filter(observationDetail => {
+                        return observationDetail.resource?.type?.concept_details.some(
+                            conceptDetail => conceptDetail.valueid === ramanConceptValueId
+                        );
+                    })
+                ],
+                xrfObservationDetails: [
+                    ...Object.values(observationDetails).filter(observationDetail => {
+                        return observationDetail.resource?.type?.concept_details.some(
+                            conceptDetail => conceptDetail.valueid === xrfConceptValueId
+                        );
+                    })
+                ],
+                instruments: Object.values(observationDetails).uniqueBy(
+                    obs => obs["resource"]?.["used instrument"]["@display_value"]
+                ).map(obs => obs["resource"]?.["used instrument"]),
+                projectDetails: [...Object.values(projectDetails)],
+                physicalThingsDetails: physicalThingsDetailsArray,
+                objectOfStudyDetails: objectOfStudyDetailsArray,
+                files: files
+            };
+
+            window.fetch(arches.urls.download_project_files, {
+                method: 'POST',
+                credentials: 'include',
+                body: JSON.stringify(data),
+                headers: {
+                    "X-CSRFToken": cookies.get('csrftoken')
+                }
+            }).then(response => {
+                if (response.ok) {
+                    self.loading(false);
+                    return response.json();
+                } else {
+                    throw response;
+                }
+            })
+            .then((json) => self.message(json.message))
+            .catch((response) => {
+                self.loading(false);
+                response.json().then(
+                    error => {
+                        params.pageVm.alert(
+                            new JsonErrorAlertViewModel(
+                                'ep-alert-red',
+                                error,
+                                null,
+                                function(){}
+                            )
+                        );
+                    });
+            });
+        };
+    }
+
+    ko.components.register('download-report', {
+        viewModel: viewModel,
+        template: downloadReportTemplate
+    });
+
+    return viewModel;
+});


### PR DESCRIPTION
Add temporary overrides to support new example report template. These files can be removed once https://github.com/archesproject/arches-for-science#1655 is merged and a beta release of 2.1.x is published.